### PR TITLE
Use correct name in upstream mirror script

### DIFF
--- a/openshift/release/mirror-upstream-branches.sh
+++ b/openshift/release/mirror-upstream-branches.sh
@@ -16,8 +16,8 @@ cat >> "$TMPDIR"/midstream_branches <<EOF
 EOF
 cp "$TMPDIR"/midstream_branches "$TMPDIR"/upstream_branches
 
-git branch --list -a "knative-extenstions/release-1.*" | cut -f3 -d'/' | cut -f2 -d'-' >> "$TMPDIR"/upstream_branches
-git branch --list -a "openshift-knative/release-v1.*" | cut -f3 -d'/' | cut -f2 -d'v' | cut -f1,2 -d'.' >> "$TMPDIR"/midstream_branches
+git branch --list -a "upstream/release-1.*" | cut -f3 -d'/' | cut -f2 -d'-' >> "$TMPDIR"/upstream_branches
+git branch --list -a "openshift/release-v1.*" | cut -f3 -d'/' | cut -f2 -d'v' | cut -f1,2 -d'.' >> "$TMPDIR"/midstream_branches
 
 sort -o "$TMPDIR"/midstream_branches "$TMPDIR"/midstream_branches
 sort -o "$TMPDIR"/upstream_branches "$TMPDIR"/upstream_branches


### PR DESCRIPTION
Branch mirroring is currently not detecting the upstream branches:

```
02:50:38  no new branch, exiting
```
e.g. [here](https://jenkins-csb-serverless-qe-master.dno.corp.redhat.com/job/ci/job/knative-nightly-ci-eventing-integrations/52/console)

This is due to the wrong name for the git remotes