### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-eventing-integrations-transform-jsonata-116

### DIFF
--- a/openshift/ci-operator/static-images/transform-jsonata/Dockerfile
+++ b/openshift/ci-operator/static-images/transform-jsonata/Dockerfile
@@ -35,7 +35,8 @@ LABEL \
       description="Red Hat OpenShift Serverless 1 Eventing Integrations Transform JSONata" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Eventing Integrations Transform JSONata" \
       io.k8s.description="Red Hat OpenShift Serverless Eventing Integrations Transform JSONata" \
-      io.openshift.tags=transform-jsonata
+      io.openshift.tags=transform-jsonata \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8"
 
 # Copy built files and dependencies
 COPY --from=builder --chown=1001:0 /app/package.json package.json


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
