### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-eventing-integrations-timer-source-116

### DIFF
--- a/openshift/ci-operator/static-images/timer-source/hermetic/Dockerfile.deps
+++ b/openshift/ci-operator/static-images/timer-source/hermetic/Dockerfile.deps
@@ -18,6 +18,9 @@ ARG JAVA_BUILDER=registry.access.redhat.com/ubi8/openjdk-21
 
 FROM $JAVA_BUILDER
 
+LABEL name="openshift-serverless-1/kn-eventing-integrations-timer-source-rhel8" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8"
+
 USER root
 
 WORKDIR /build


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
