### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-eventing-integrations-aws-sns-sink-116

### DIFF
--- a/openshift/ci-operator/static-images/aws-sns-sink/hermetic/Dockerfile
+++ b/openshift/ci-operator/static-images/aws-sns-sink/hermetic/Dockerfile
@@ -39,7 +39,8 @@ USER 185
 
 LABEL \
       com.redhat.component="openshift-serverless-1-eventing-integrations-aws-sns-sink-rhel8-container" \
-      name="openshift-serverless-1/eventing-integrations-aws-sns-sink-rhel8" \
+      name="openshift-serverless-1/kn-eventing-integrations-aws-sns-sink-rhel8" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8" \
       version=$VERSION \
       release=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Eventing Integrations AWS SNS Sink" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
